### PR TITLE
Add FreeBSD support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["mac", "address", "network", "interface"]
 
 [dependencies]
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
 nix = "0.16"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `mac_address` provides a cross platform way to retrieve the [MAC address](https://en.wikipedia.org/wiki/MAC_address) of network hardware.
 
-Supported platforms: Linux, Windows, MacOS
+Supported platforms: Linux, Windows, MacOS, FreeBSD
 
 ## Example
 

--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -6,6 +6,9 @@ fn main() {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let name = "eth0";
 
+    #[cfg(any(target_os = "freebsd"))]
+    let name = "em0";
+
     #[cfg(target_os = "windows")]
     let name = "Ethernet";
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2,7 +2,7 @@
 #[path = "windows.rs"]
 mod internal;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 #[path = "linux.rs"]
 mod internal;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,21 +2,21 @@
 //! network hardware. See [the Wikipedia
 //! entry](https://en.wikipedia.org/wiki/MAC_address) for more information.
 //!
-//! Supported platforms: Linux, Windows, MacOS
+//! Supported platforms: Linux, Windows, MacOS, FreeBSD
 
 #![deny(missing_docs)]
 
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 extern crate nix;
 
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
 mod os;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 #[path = "linux.rs"]
 mod os;
 
@@ -32,7 +32,7 @@ pub enum MacAddressError {
     InternalError,
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 impl From<nix::Error> for MacAddressError {
     fn from(_: nix::Error) -> MacAddressError {
         MacAddressError::InternalError


### PR DESCRIPTION
This adds FreeBSD support.  All examples work and tests pass on the following `uname -a`:

> `FreeBSD <myhost> 12.1-RELEASE FreeBSD 12.1-RELEASE r354233 GENERIC  amd64`

The only issues I can see is that some FreeBSD installations use igb0 as their default interface rather than em0 depending on how the devices enumerate, so examples/lookup.rs would break if this were the case..  Not sure if that is a deal breaker here, but I just thought I would point it out.

Also the feature flag is really overloading linux.rs, but I don't think it really needs to change for functionality reasons.  If it is desired to support all unix-like operating systems, the feature flag `target_family = "unix"` could be used, though I think that would have to be handled with care.