### PR TITLE
Add name_by_mac_address function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,11 @@ pub fn mac_address_by_name(name: &str) -> Result<Option<MacAddress>, MacAddressE
     })
 }
 
+/// Attempts to look up the interface name via MAC address.
+pub fn name_by_mac_address(mac: &MacAddress) -> Result<Option<String>, MacAddressError> {
+    os::get_ifname(&mac.bytes)
+}
+
 impl MacAddress {
     /// Returns the array of MAC address bytes.
     pub fn bytes(self) -> [u8; 6] {
@@ -249,5 +254,14 @@ mod tests {
             )
             .unwrap(),
         );
+    }
+
+    #[test]
+    fn convert() {
+        for mac in MacAddressIterator::new().unwrap() {
+            let name = name_by_mac_address(&mac).unwrap().unwrap();
+            let mac2 = mac_address_by_name(&name).unwrap().unwrap();
+            assert_eq!(mac, mac2);
+        }
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -27,3 +27,21 @@ pub fn get_mac(name: Option<&str>) -> Result<Option<[u8; 6]>, MacAddressError> {
 
     Ok(None)
 }
+
+pub fn get_ifname(mac: &[u8; 6]) -> Result<Option<String>, MacAddressError> {
+    let ifiter = getifaddrs()?;
+
+    for interface in ifiter {
+        if let Some(address) = interface.address {
+            if let SockAddr::Link(link) = address {
+                let bytes = link.addr();
+
+                if &bytes == mac {
+                    return Ok(Some(interface.interface_name));
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}


### PR DESCRIPTION
This PR adds `name_by_mac_address` function to get the interface name via MAC address: #14.