### PR TITLE
Add Default derive to MacAddress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for MacParseError {
 impl std::error::Error for MacParseError {}
 
 /// Contains the individual bytes of the MAC address.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "&str"))]
 pub struct MacAddress {


### PR DESCRIPTION
This PR adds `Default` derive to `MacAddress`.
`MacAddress::default()` can be shorthand of `MacAddress::new([0, 0, 0, 0, 0, 0])`.