### PR TITLE
Add support for OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mac", "address", "network", "interface"]
 [dependencies]
 serde = { version = "1.0.117", features = ["derive"], optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 nix = "0.23.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `mac_address` provides a cross platform way to retrieve the [MAC address](https://en.wikipedia.org/wiki/MAC_address) of network hardware.
 
-Supported platforms: Linux, Windows, MacOS, FreeBSD
+Supported platforms: Linux, Windows, MacOS, FreeBSD, OpenBSD
 
 ## Example
 

--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -4,7 +4,7 @@ fn main() {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     let name = "eth0";
 
-    #[cfg(any(target_os = "freebsd"))]
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
     let name = "em0";
 
     #[cfg(target_os = "windows")]

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2,7 +2,7 @@
 #[path = "windows.rs"]
 mod internal;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 #[path = "linux.rs"]
 mod internal;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! network hardware. See [the Wikipedia
 //! entry](https://en.wikipedia.org/wiki/MAC_address) for more information.
 //!
-//! Supported platforms: Linux, Windows, MacOS, FreeBSD
+//! Supported platforms: Linux, Windows, MacOS, FreeBSD, OpenBSD
 
 #![deny(missing_docs)]
 
@@ -10,7 +10,7 @@
 #[path = "windows.rs"]
 mod os;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 #[path = "linux.rs"]
 mod os;
 
@@ -26,7 +26,7 @@ pub enum MacAddressError {
     InternalError,
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 impl From<nix::Error> for MacAddressError {
     fn from(_: nix::Error) -> MacAddressError {
         MacAddressError::InternalError


### PR DESCRIPTION
* `cargo build` runs without error
* `cargo test` passes all tests
* `cargo run --example lookup` correctly fetches the local MAC address

Tested with cargo 1.59.0 on OpenBSD 7.1-stable

This commit replicates what PR #15 did for FreeBSD support.