### PR TITLE
Add support for OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mac", "address", "network", "interface"]
 [dependencies]
 serde = { version = "1.0.117", features = ["derive"], optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 nix = "0.23.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `mac_address` provides a cross platform way to retrieve the [MAC address](https://en.wikipedia.org/wiki/MAC_address) of network hardware.
 
-Supported platforms: Linux, Windows, MacOS, FreeBSD
+Supported platforms: Linux, Windows, MacOS, FreeBSD, OpenBSD
 
 ## Example
 

--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -7,6 +7,9 @@ fn main() {
     #[cfg(any(target_os = "freebsd"))]
     let name = "em0";
 
+    #[cfg(any(target_os = "openbsd"))]
+    let name = "fxp0";
+
     #[cfg(target_os = "windows")]
     let name = "Ethernet";
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2,7 +2,7 @@
 #[path = "windows.rs"]
 mod internal;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 #[path = "linux.rs"]
 mod internal;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #[path = "windows.rs"]
 mod os;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 #[path = "linux.rs"]
 mod os;
 
@@ -26,7 +26,7 @@ pub enum MacAddressError {
     InternalError,
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 impl From<nix::Error> for MacAddressError {
     fn from(_: nix::Error) -> MacAddressError {
         MacAddressError::InternalError


### PR DESCRIPTION
This works just fine on OpenBDS.

Tested by running `cargo test` and all the examples.