### PR TITLE
Use the `windows-sys` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ serde = { version = "1.0.198", features = ["derive"], optional = true }
 nix = { version = "0.28", features = ["net"] }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winerror", "ws2def", "iphlpapi"] }
+windows-sys = { version = "0.59", features = [
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis"
+]}
 
 [dev-dependencies]
 serde_test = "1.0.117"

--- a/src/iter/windows.rs
+++ b/src/iter/windows.rs
@@ -1,12 +1,13 @@
+use windows_sys::Win32::NetworkManagement::IpHelper::IP_ADAPTER_ADDRESSES_LH;
+
 use crate::os;
 use crate::{MacAddress, MacAddressError};
-use winapi::um::iptypes::PIP_ADAPTER_ADDRESSES;
 
 /// An iterator over all available MAC addresses on the system.
 pub struct MacAddressIterator {
     // So we don't UAF during iteration.
     _buffer: os::AdaptersList,
-    ptr: PIP_ADAPTER_ADDRESSES,
+    ptr: *mut IP_ADAPTER_ADDRESSES_LH,
 }
 
 impl MacAddressIterator {


### PR DESCRIPTION
Replaces the "potentially unmaintained" `winapi` crate by the `windows-sys` crate, officially supported by Microsoft.

I ran the unit tests and created a test app which iterates through the mac addresses found on my machine. Behavior of the library seem unchanged.

The only downside is that the MSRV of this crate is bumped to 1.60, but there is currently no policy regarding this.