### PR TITLE
feat: add NetBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["mac", "address", "network", "interface"]
 [dependencies]
 serde = { version = "1.0.198", features = ["derive"], optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "android", target_os = "illumos"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "android", target_os = "illumos"))'.dependencies]
 nix = { version = "0.28", features = ["net"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -7,6 +7,9 @@ fn main() {
     #[cfg(target_os = "freebsd")]
     let name = "em0";
 
+    #[cfg(target_os = "netbsd")]
+    let name = "igc0";
+
     #[cfg(target_os = "openbsd")]
     let name = "fxp0";
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -6,6 +6,7 @@ mod internal;
     target_os = "linux",
     target_os = "macos",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd",
     target_os = "android",
     target_os = "illumos",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! network hardware. See [the Wikipedia
 //! entry](https://en.wikipedia.org/wiki/MAC_address) for more information.
 //!
-//! Supported platforms: Linux, Windows, MacOS, FreeBSD
+//! Supported platforms: Linux, Windows, MacOS, FreeBSD, NetBSD
 
 #![deny(missing_docs)]
 
@@ -14,6 +14,7 @@ mod os;
     target_os = "linux",
     target_os = "macos",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd",
     target_os = "android",
     target_os = "illumos",
@@ -37,6 +38,7 @@ pub enum MacAddressError {
     target_os = "linux",
     target_os = "macos",
     target_os = "freebsd",
+    target_os = "netbsd",
     target_os = "openbsd",
     target_os = "android",
     target_os = "illumos",


### PR DESCRIPTION
This is newly pulled in by [jj](https://github.com/jj-vcs/jj/issues/5628), so please merge this NetBSD support. Thank you.

Survives 'cargo build' and 'cargo test' on NetBSD 10.99.12/x86_64.